### PR TITLE
feat: add group views with mock data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import DashboardView from "./views/DashboardView.tsx";
 import SearchView from "./views/SearchView.tsx";
 import MovieDetailsView from "./views/MovieDetailsView.tsx";
 import UserView from "./views/UserView.tsx";
+import GroupsListView from "./views/GroupsListView.tsx";
+import GroupDetailsView from "./views/GroupDetailsView.tsx";
 
 function App() {
     return (
@@ -16,6 +18,8 @@ function App() {
                         <Route path="/" component={DashboardView}/>
                         <Route path="/search" component={SearchView}/>
                         <Route path="/movie/:id" component={MovieDetailsView}/>
+                        <Route path="/groups" component={GroupsListView}/>
+                        <Route path="/groups/:id" component={GroupDetailsView}/>
                         <Route path="/user/:id">{params => <UserView id={params.id} />}</Route>
                         <Route><h1>404 Not Found</h1></Route>
                     </Switch>

--- a/src/components/groups/GroupHeader.tsx
+++ b/src/components/groups/GroupHeader.tsx
@@ -1,0 +1,51 @@
+import { Badge, Button, Card, Group, Image, Stack, Text, Title } from "@mantine/core"
+import { IconSettings } from "@tabler/icons-react"
+import dayjs from "dayjs"
+import type { GroupSummary } from "../../types/group"
+
+interface GroupHeaderProps {
+  group: GroupSummary
+  nextShowtimeLabel: string
+  isOwner: boolean
+  onOpenSettings: () => void
+}
+
+export function GroupHeader({ group, nextShowtimeLabel, isOwner, onOpenSettings }: GroupHeaderProps) {
+  return (
+    <Card withBorder padding="lg" radius="lg" shadow="sm">
+      <Card.Section>
+        <Image src={group.coverImage} alt={`${group.name} banner`} h={220} fit="cover" />
+      </Card.Section>
+
+      <Stack gap="md" mt="md">
+        <Group justify="space-between" align="flex-start">
+          <Stack gap={4}>
+            <Title order={2}>{group.name}</Title>
+            <Text size="sm" c="dimmed">
+              Founded {dayjs(group.createdAt).format("MMMM D, YYYY")}
+            </Text>
+          </Stack>
+          {isOwner && (
+            <Button variant="outline" leftSection={<IconSettings size={16} />} onClick={onOpenSettings}>
+              Group settings
+            </Button>
+          )}
+        </Group>
+
+        <Text>{group.description}</Text>
+
+        <Group gap="xs">
+          {group.tags.map((tag) => (
+            <Badge key={tag} variant="light" radius="sm">
+              {tag}
+            </Badge>
+          ))}
+        </Group>
+
+        <Text size="sm" c="dimmed">
+          {nextShowtimeLabel}
+        </Text>
+      </Stack>
+    </Card>
+  )
+}

--- a/src/components/groups/GroupJoinRequestsSection.tsx
+++ b/src/components/groups/GroupJoinRequestsSection.tsx
@@ -1,0 +1,60 @@
+import { Card, Group, Stack, Text, Title, Button, Badge } from "@mantine/core"
+import type { GroupJoinRequest } from "../../types/group"
+
+interface GroupJoinRequestsSectionProps {
+  requests: GroupJoinRequest[]
+  onDecision: (requestId: string, action: "accept" | "decline") => void
+  isOwner: boolean
+}
+
+export function GroupJoinRequestsSection({ requests, onDecision, isOwner }: GroupJoinRequestsSectionProps) {
+  if (!isOwner) {
+    return null
+  }
+
+  return (
+    <Card withBorder radius="lg" padding="lg" shadow="sm">
+      <Group justify="space-between" mb="md">
+        <Title order={3}>Pending requests</Title>
+        <Badge variant="light" color={requests.length > 0 ? "yellow" : "gray"}>
+          {requests.length} waiting
+        </Badge>
+      </Group>
+
+      {requests.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No pending invitations right now. Share your invite link from the settings panel when you&apos;re ready to
+          expand the crew.
+        </Text>
+      ) : (
+        <Stack gap="sm">
+          {requests.map((request) => (
+            <Card key={request.id} withBorder padding="sm" radius="md" shadow="xs">
+              <Group justify="space-between" align="flex-start">
+                <Stack gap={4}>
+                  <Text fw={600}>{request.name}</Text>
+                  <Text size="xs" c="dimmed">
+                    Requested on {new Date(request.requestedAt).toLocaleString()}
+                  </Text>
+                  {request.message && (
+                    <Text size="sm" c="dimmed">
+                      “{request.message}”
+                    </Text>
+                  )}
+                </Stack>
+                <Group gap="xs">
+                  <Button size="xs" variant="outline" onClick={() => onDecision(request.id, "decline")}>
+                    Decline
+                  </Button>
+                  <Button size="xs" onClick={() => onDecision(request.id, "accept")}>
+                    Accept
+                  </Button>
+                </Group>
+              </Group>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Card>
+  )
+}

--- a/src/components/groups/GroupMembersSection.tsx
+++ b/src/components/groups/GroupMembersSection.tsx
@@ -1,0 +1,105 @@
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Card,
+  Group,
+  Menu,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core"
+import { IconDotsVertical, IconLogout, IconUserMinus } from "@tabler/icons-react"
+import type { GroupMember } from "../../types/group"
+
+interface GroupMembersSectionProps {
+  members: GroupMember[]
+  currentUserId?: number
+  isOwner: boolean
+  onRemoveMember: (memberId: number) => void
+  onLeaveGroup: () => void
+}
+
+const roleLabels: Record<GroupMember["role"], string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+}
+
+export function GroupMembersSection({
+  members,
+  currentUserId,
+  isOwner,
+  onRemoveMember,
+  onLeaveGroup,
+}: GroupMembersSectionProps) {
+  return (
+    <Card withBorder radius="lg" padding="lg" shadow="sm">
+      <Group justify="space-between" mb="md">
+        <Title order={3}>Members</Title>
+        {currentUserId && (
+          <Tooltip label="Leave group" position="left" withArrow>
+            <ActionIcon color="red" variant="light" onClick={onLeaveGroup} aria-label="Leave group">
+              <IconLogout size={18} />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </Group>
+
+      <Stack gap="sm">
+        {members.map((member) => {
+          const isCurrentUser = member.id === currentUserId
+          const canKick = isOwner && !isCurrentUser && member.role !== "owner"
+
+          return (
+            <Card key={member.id} withBorder padding="sm" radius="md" shadow="xs">
+              <Group justify="space-between">
+                <Group gap="md">
+                  <Avatar src={member.avatarUrl} radius="xl">
+                    {member.name.at(0)}
+                  </Avatar>
+                  <Stack gap={2}>
+                    <Text fw={600}>{member.name}</Text>
+                    <Group gap="xs">
+                      <Badge size="sm" variant="light">
+                        {roleLabels[member.role]}
+                      </Badge>
+                      <Text size="xs" c="dimmed">
+                        Joined {new Date(member.joinedAt).toLocaleDateString()}
+                      </Text>
+                      {isCurrentUser && (
+                        <Badge size="sm" color="blue" variant="light">
+                          You
+                        </Badge>
+                      )}
+                    </Group>
+                  </Stack>
+                </Group>
+
+                {canKick && (
+                  <Menu position="bottom-end" withinPortal>
+                    <Menu.Target>
+                      <ActionIcon variant="subtle" aria-label={`Manage ${member.name}`}>
+                        <IconDotsVertical size={18} />
+                      </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                      <Menu.Item
+                        leftSection={<IconUserMinus size={16} />}
+                        color="red"
+                        onClick={() => onRemoveMember(member.id)}
+                      >
+                        Remove from group
+                      </Menu.Item>
+                    </Menu.Dropdown>
+                  </Menu>
+                )}
+              </Group>
+            </Card>
+          )
+        })}
+      </Stack>
+    </Card>
+  )
+}

--- a/src/components/groups/GroupShowtimesSection.tsx
+++ b/src/components/groups/GroupShowtimesSection.tsx
@@ -1,0 +1,75 @@
+import { ActionIcon, Card, Group, Stack, Text, Title, Tooltip } from "@mantine/core"
+import { IconTrash } from "@tabler/icons-react"
+import dayjs from "dayjs"
+import type { GroupMember, GroupShowtime } from "../../types/group"
+
+interface GroupShowtimesSectionProps {
+  showtimes: GroupShowtime[]
+  members: GroupMember[]
+  isOwner: boolean
+  onRemoveShowtime: (id: string) => void
+}
+
+export function GroupShowtimesSection({ showtimes, members, isOwner, onRemoveShowtime }: GroupShowtimesSectionProps) {
+  const memberById = new Map(members.map((member) => [member.id, member]))
+
+  if (showtimes.length === 0) {
+    return (
+      <Card withBorder radius="lg" padding="lg" shadow="sm">
+        <Title order={3} mb="xs">
+          Upcoming theatre times
+        </Title>
+        <Text size="sm" c="dimmed">
+          No screenings scheduled yet. Share a Finnkino link with the group to get started.
+        </Text>
+      </Card>
+    )
+  }
+
+  return (
+    <Card withBorder radius="lg" padding="lg" shadow="sm">
+      <Title order={3} mb="md">
+        Upcoming theatre times
+      </Title>
+
+      <Stack gap="md">
+        {showtimes.map((showtime) => {
+          const addedBy = memberById.get(showtime.addedBy)
+          return (
+            <Card key={showtime.id} withBorder padding="md" radius="md" shadow="xs">
+              <Group justify="space-between" align="flex-start">
+                <Stack gap={4}>
+                  <Text fw={600}>{showtime.movieTitle}</Text>
+                  <Text size="sm" c="dimmed">
+                    {showtime.theatre}
+                  </Text>
+                  <Text size="sm">{dayjs(showtime.startsAt).format("dddd, MMM D YYYY HH:mm")}</Text>
+                  <Text size="xs" c="dimmed">
+                    Added by {addedBy?.name ?? "Member"}
+                  </Text>
+                  {showtime.notes && (
+                    <Text size="sm" c="dimmed">
+                      {showtime.notes}
+                    </Text>
+                  )}
+                </Stack>
+                {isOwner && (
+                  <Tooltip label="Remove showtime" withArrow>
+                    <ActionIcon
+                      variant="light"
+                      color="red"
+                      onClick={() => onRemoveShowtime(showtime.id)}
+                      aria-label="Remove showtime"
+                    >
+                      <IconTrash size={18} />
+                    </ActionIcon>
+                  </Tooltip>
+                )}
+              </Group>
+            </Card>
+          )
+        })}
+      </Stack>
+    </Card>
+  )
+}

--- a/src/components/groups/GroupSummaryCard.tsx
+++ b/src/components/groups/GroupSummaryCard.tsx
@@ -1,0 +1,96 @@
+import { Avatar, Badge, Button, Card, Group, Image, Stack, Text, Tooltip } from "@mantine/core"
+import { IconCalendarClock, IconChevronRight, IconUsers } from "@tabler/icons-react"
+import dayjs from "dayjs"
+import relativeTime from "dayjs/plugin/relativeTime"
+import type { GroupSummary } from "../../types/group"
+
+dayjs.extend(relativeTime)
+
+interface GroupSummaryCardProps {
+  group: GroupSummary
+  onViewGroup: (groupId: number) => void
+}
+
+export function GroupSummaryCard({ group, onViewGroup }: GroupSummaryCardProps) {
+  const nextShowtime = [...group.showtimes]
+    .sort((a, b) => dayjs(a.startsAt).valueOf() - dayjs(b.startsAt).valueOf())
+    .find((showtime) => dayjs(showtime.startsAt).isAfter(dayjs()))
+
+  return (
+    <Card withBorder radius="lg" shadow="sm" padding="lg" h="100%">
+      <Card.Section>
+        <Image src={group.coverImage} h={160} alt={`${group.name} banner`} fit="cover" />
+      </Card.Section>
+
+      <Stack gap="md" mt="md" justify="space-between" h="calc(100% - 160px)">
+        <Stack gap="xs">
+          <Group justify="space-between">
+            <Text fw={700} size="lg">
+              {group.name}
+            </Text>
+            <Group gap="xs">
+              <IconUsers size={16} stroke={1.8} />
+              <Text size="sm" c="dimmed">
+                {group.members.length} members
+              </Text>
+            </Group>
+          </Group>
+
+          <Text size="sm" c="dimmed" lineClamp={2}>
+            {group.description}
+          </Text>
+
+          <Group gap="xs">
+            {group.tags.map((tag) => (
+              <Badge key={tag} variant="light" radius="sm" size="sm">
+                {tag}
+              </Badge>
+            ))}
+          </Group>
+        </Stack>
+
+        <Stack gap="sm">
+          {nextShowtime ? (
+            <Tooltip
+              label={`${dayjs(nextShowtime.startsAt).format("dddd, MMM D YYYY HH:mm")} @ ${nextShowtime.theatre}`}
+              withArrow
+            >
+              <Group gap="xs" align="center">
+                <IconCalendarClock size={16} stroke={1.8} />
+                <Text size="sm">
+                  Next screening {dayjs(nextShowtime.startsAt).fromNow()}
+                </Text>
+              </Group>
+            </Tooltip>
+          ) : (
+            <Group gap="xs" align="center">
+              <IconCalendarClock size={16} stroke={1.8} />
+              <Text size="sm" c="dimmed">
+                No upcoming showtimes scheduled
+              </Text>
+            </Group>
+          )}
+
+          <Group gap="xs">
+            {group.members.slice(0, 4).map((member) => (
+              <Tooltip key={member.id} label={`${member.name} • ${member.role}`} withArrow>
+                <Avatar src={member.avatarUrl} radius="xl" size="sm">
+                  {member.name.at(0)}
+                </Avatar>
+              </Tooltip>
+            ))}
+            {group.members.length > 4 && (
+              <Avatar radius="xl" size="sm" color="gray" variant="light">
+                +{group.members.length - 4}
+              </Avatar>
+            )}
+          </Group>
+
+          <Button rightSection={<IconChevronRight size={16} />} onClick={() => onViewGroup(group.id)}>
+            View group
+          </Button>
+        </Stack>
+      </Stack>
+    </Card>
+  )
+}

--- a/src/data/mockGroups.ts
+++ b/src/data/mockGroups.ts
@@ -1,0 +1,178 @@
+import type { GroupSummary } from "../types/group"
+
+export const mockGroups: GroupSummary[] = [
+  {
+    id: 1,
+    name: "Midnight Premiere Squad",
+    description:
+      "Obsessed with catching the very first screenings of genre gems and blockbusters across Finland.",
+    ownerId: 101,
+    tags: ["Premiere", "Sci-Fi", "Action"],
+    coverImage: "https://picsum.photos/1280/720",
+    members: [
+      {
+        id: 101,
+        name: "Ella Rantanen",
+        role: "owner",
+        avatarUrl: "https://i.pravatar.cc/100?img=32",
+        joinedAt: "2024-02-12T10:30:00+02:00",
+      },
+      {
+        id: 102,
+        name: "Lukas Virtanen",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=45",
+        joinedAt: "2024-04-01T18:05:00+03:00",
+      },
+      {
+        id: 103,
+        name: "Noora Miettinen",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=12",
+        joinedAt: "2024-05-20T21:10:00+03:00",
+      },
+    ],
+    showtimes: [
+      {
+        id: "show-1",
+        movieTitle: "Dune: Part Two",
+        theatre: "Finnkino Tennispalatsi, Helsinki",
+        startsAt: "2025-10-07T23:30:00+03:00",
+        addedBy: 101,
+        notes: "Meet 30 minutes earlier for merch swap",
+      },
+      {
+        id: "show-2",
+        movieTitle: "Blade Runner 2099",
+        theatre: "Finnkino Itis, Helsinki",
+        startsAt: "2025-11-12T21:45:00+02:00",
+        addedBy: 102,
+      },
+    ],
+    pendingRequests: [
+      {
+        id: "req-1",
+        userId: 201,
+        name: "Jesse Salmi",
+        requestedAt: "2025-09-25T14:20:00+03:00",
+        message: "Huge sci-fi nerd, always up for midnight releases!",
+      },
+    ],
+    createdAt: "2024-01-15T08:00:00+02:00",
+  },
+  {
+    id: 2,
+    name: "Saturday Classics",
+    description:
+      "Weekly matinees dedicated to the greatest hits from IMDB Top 250 and European cinema treasures.",
+    ownerId: 102,
+    tags: ["Classics", "Matinee", "Discussion"],
+    coverImage: "https://picsum.photos/1280/720",
+    members: [
+      {
+        id: 102,
+        name: "Lukas Virtanen",
+        role: "owner",
+        avatarUrl: "https://i.pravatar.cc/100?img=45",
+        joinedAt: "2023-10-01T11:00:00+03:00",
+      },
+      {
+        id: 104,
+        name: "Venla Lehtinen",
+        role: "admin",
+        avatarUrl: "https://i.pravatar.cc/100?img=55",
+        joinedAt: "2023-10-01T11:00:00+03:00",
+      },
+      {
+        id: 105,
+        name: "Matias Oja",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=24",
+        joinedAt: "2024-03-10T16:00:00+02:00",
+      },
+      {
+        id: 106,
+        name: "Sara Laine",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=48",
+        joinedAt: "2024-06-05T14:00:00+03:00",
+      },
+    ],
+    showtimes: [
+      {
+        id: "show-3",
+        movieTitle: "Casablanca",
+        theatre: "Finnkino Plevna, Tampere",
+        startsAt: "2025-10-18T16:00:00+03:00",
+        addedBy: 104,
+        notes: "Post-screening coffee at the lobby",
+      },
+      {
+        id: "show-4",
+        movieTitle: "Cinema Paradiso",
+        theatre: "Finnkino Fantasia, Jyväskylä",
+        startsAt: "2025-10-25T15:30:00+03:00",
+        addedBy: 102,
+      },
+    ],
+    pendingRequests: [
+      {
+        id: "req-2",
+        userId: 202,
+        name: "Hanna Koski",
+        requestedAt: "2025-09-30T09:45:00+03:00",
+      },
+      {
+        id: "req-3",
+        userId: 203,
+        name: "Aleksi Saarinen",
+        requestedAt: "2025-09-29T19:12:00+03:00",
+        message: "I host a weekly podcast about film history.",
+      },
+    ],
+    createdAt: "2023-09-20T10:00:00+03:00",
+  },
+  {
+    id: 3,
+    name: "Finnkino Family Circle",
+    description:
+      "Family-friendly sessions aligned with Finnkino's best new releases for all ages.",
+    ownerId: 107,
+    tags: ["Family", "Finnkino", "Animation"],
+    coverImage: "https://picsum.photos/1280/720",
+    members: [
+      {
+        id: 107,
+        name: "Petra Korhonen",
+        role: "owner",
+        avatarUrl: "https://i.pravatar.cc/100?img=5",
+        joinedAt: "2024-05-12T08:30:00+03:00",
+      },
+      {
+        id: 108,
+        name: "Jari Lappalainen",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=36",
+        joinedAt: "2024-07-01T09:00:00+03:00",
+      },
+      {
+        id: 109,
+        name: "Mila Lappalainen",
+        role: "member",
+        avatarUrl: "https://i.pravatar.cc/100?img=68",
+        joinedAt: "2024-07-01T09:00:00+03:00",
+      },
+    ],
+    showtimes: [
+      {
+        id: "show-5",
+        movieTitle: "Inside Out 3",
+        theatre: "Finnkino Odeon, Espoo",
+        startsAt: "2025-10-19T13:00:00+03:00",
+        addedBy: 108,
+      },
+    ],
+    pendingRequests: [],
+    createdAt: "2024-05-01T10:00:00+03:00",
+  },
+]

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -89,11 +89,20 @@ const DefaultLayout = ({children}: React.PropsWithChildren) => {
             <AppShell header={{height: 60}} padding="md">
                 <AppShell.Header className={classes.appShellHeader}>
                     <Group h="100%" px="md" justify="space-between">
-                        <Link href="/">
-                            <UnstyledButton>
-                                <Text size="lg" fw={700}>Movie App</Text>
-                            </UnstyledButton>
-                        </Link>
+                        <Group gap="lg" align="center">
+                            <Link href="/">
+                                <UnstyledButton>
+                                    <Text size="lg" fw={700}>Movie App</Text>
+                                </UnstyledButton>
+                            </Link>
+                            <Group gap="md" visibleFrom="md">
+                                <Link href="/groups">
+                                    <UnstyledButton>
+                                        <Text size="sm" fw={600}>Groups</Text>
+                                    </UnstyledButton>
+                                </Link>
+                            </Group>
+                        </Group>
                         <Group visibleFrom="sm">{searchForm}</Group>
                         <Box visibleFrom="sm">{authControls}</Box>
                         <Burger opened={drawerOpened} onClick={toggleDrawer} hiddenFrom="sm" size="sm"/>
@@ -103,6 +112,9 @@ const DefaultLayout = ({children}: React.PropsWithChildren) => {
             </AppShell>
             <Drawer opened={drawerOpened} onClose={closeDrawer} title="Navigation" padding="md" hiddenFrom="sm">
                 <Stack>
+                    <Link href="/groups">
+                        <Button variant="subtle" onClick={closeDrawer}>Groups</Button>
+                    </Link>
                     {searchForm}
                     {authControls}
                 </Stack>

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,0 +1,39 @@
+export type GroupRole = "owner" | "admin" | "member"
+
+export interface GroupMember {
+  id: number
+  name: string
+  role: GroupRole
+  avatarUrl?: string
+  joinedAt: string
+}
+
+export interface GroupShowtime {
+  id: string
+  movieTitle: string
+  theatre: string
+  startsAt: string
+  addedBy: number
+  notes?: string
+}
+
+export interface GroupJoinRequest {
+  id: string
+  userId: number
+  name: string
+  requestedAt: string
+  message?: string
+}
+
+export interface GroupSummary {
+  id: number
+  name: string
+  description: string
+  ownerId: number
+  tags: string[]
+  coverImage: string
+  members: GroupMember[]
+  showtimes: GroupShowtime[]
+  pendingRequests: GroupJoinRequest[]
+  createdAt: string
+}

--- a/src/views/GroupDetailsView.tsx
+++ b/src/views/GroupDetailsView.tsx
@@ -1,0 +1,257 @@
+import {
+  Alert,
+  Button,
+  Container,
+  Group,
+  Loader,
+  Modal,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@mantine/core"
+import { useDisclosure } from "@mantine/hooks"
+import { useEffect, useMemo, useState } from "react"
+import { useLocation, useRoute } from "wouter"
+import { IconCheck, IconInfoCircle } from "@tabler/icons-react"
+import { UseAuth } from "../context/AuthProvider"
+import { mockGroups } from "../data/mockGroups"
+import type { GroupMember, GroupSummary } from "../types/group"
+import { GroupHeader } from "../components/groups/GroupHeader"
+import { GroupShowtimesSection } from "../components/groups/GroupShowtimesSection"
+import { GroupMembersSection } from "../components/groups/GroupMembersSection"
+import { GroupJoinRequestsSection } from "../components/groups/GroupJoinRequestsSection"
+import dayjs from "dayjs"
+import relativeTime from "dayjs/plugin/relativeTime"
+
+dayjs.extend(relativeTime)
+
+const GroupDetailsView = () => {
+  const [match, params] = useRoute("/groups/:id")
+  const [, navigate] = useLocation()
+  const groupId = params?.id ? Number(params.id) : undefined
+
+  const [group, setGroup] = useState<GroupSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null)
+  const [showSettingsModal, settingsModalHandlers] = useDisclosure(false)
+  const [memberRemovalCandidate, setMemberRemovalCandidate] = useState<GroupMember | null>(null)
+
+  const { user } = UseAuth()
+
+  useEffect(() => {
+    if (!match || !groupId) {
+      setIsLoading(false)
+      return
+    }
+
+  const existingGroup = mockGroups.find((item) => item.id === groupId) ?? null
+  setGroup(existingGroup ? JSON.parse(JSON.stringify(existingGroup)) : null)
+    setIsLoading(false)
+  }, [groupId, match])
+
+  const currentUserId = useMemo(() => {
+    if (user) return user.id
+    return group?.ownerId
+  }, [group?.ownerId, user])
+
+  const isOwner = group ? currentUserId === group.ownerId : false
+
+  const nextShowtimeLabel = useMemo(() => {
+    if (!group || group.showtimes.length === 0) {
+      return "No upcoming theatre times yet"
+    }
+
+    const next = [...group.showtimes]
+      .sort((a, b) => dayjs(a.startsAt).valueOf() - dayjs(b.startsAt).valueOf())
+      .find((item) => dayjs(item.startsAt).isAfter(dayjs()))
+
+    if (!next) {
+      return "All listed screenings are in the past"
+    }
+
+    return `Next screening ${dayjs(next.startsAt).fromNow()} at ${next.theatre}`
+  }, [group])
+
+  const handleRemoveShowtime = (showtimeId: string) => {
+    setGroup((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        showtimes: prev.showtimes.filter((show) => show.id !== showtimeId),
+      }
+    })
+    setFeedback({ type: "success", message: "Showtime removed from the agenda." })
+  }
+
+  const handleRemoveMember = (memberId: number) => {
+    setGroup((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        members: prev.members.filter((member) => member.id !== memberId),
+      }
+    })
+    setFeedback({ type: "success", message: "Member removed from the group." })
+    setMemberRemovalCandidate(null)
+  }
+
+  const handleJoinRequestDecision = (requestId: string, decision: "accept" | "decline") => {
+    setGroup((prev) => {
+      if (!prev) return prev
+      const request = prev.pendingRequests.find((item) => item.id === requestId)
+      if (!request) return prev
+
+      const updatedRequests = prev.pendingRequests.filter((item) => item.id !== requestId)
+
+      if (decision === "decline") {
+        setFeedback({ type: "success", message: `${request.name} has been declined.` })
+        return {
+          ...prev,
+          pendingRequests: updatedRequests,
+        }
+      }
+
+      const newMember: GroupMember = {
+        id: request.userId,
+        name: request.name,
+        role: "member",
+        joinedAt: new Date().toISOString(),
+      }
+
+      setFeedback({ type: "success", message: `${request.name} is now part of the group!` })
+
+      return {
+        ...prev,
+        pendingRequests: updatedRequests,
+        members: [...prev.members, newMember],
+      }
+    })
+  }
+
+  const handleLeaveGroup = () => {
+    if (!currentUserId || !group) return
+
+    if (isOwner) {
+      setFeedback({ type: "error", message: "Group owners can transfer ownership in settings before leaving." })
+      settingsModalHandlers.open()
+      return
+    }
+
+    setGroup((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        members: prev.members.filter((member) => member.id !== currentUserId),
+      }
+    })
+    setFeedback({ type: "success", message: "You have left the group." })
+    navigate("/groups")
+  }
+
+  if (isLoading) {
+    return (
+      <Container size="lg" py="xl">
+        <Group justify="center">
+          <Loader />
+        </Group>
+      </Container>
+    )
+  }
+
+  if (!group) {
+    return (
+      <Container size="lg" py="xl">
+        <Alert color="red" variant="light" title="Group not found">
+          This group doesn&apos;t exist in our demo data yet. Return to the groups overview to try another one.
+        </Alert>
+      </Container>
+    )
+  }
+
+  return (
+    <Container size="xl" py="xl">
+      <Stack gap="xl">
+        {feedback && (
+          <Alert
+            color={feedback.type === "success" ? "teal" : "red"}
+            icon={<IconCheck size={18} />}
+            withCloseButton
+            onClose={() => setFeedback(null)}
+            variant="light"
+          >
+            {feedback.message}
+          </Alert>
+        )}
+
+        <GroupHeader
+          group={group}
+          nextShowtimeLabel={nextShowtimeLabel}
+          isOwner={isOwner}
+          onOpenSettings={settingsModalHandlers.open}
+        />
+
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl">
+          <GroupShowtimesSection
+            showtimes={group.showtimes}
+            members={group.members}
+            isOwner={isOwner}
+            onRemoveShowtime={handleRemoveShowtime}
+          />
+          <Stack gap="xl">
+            <GroupMembersSection
+              members={group.members}
+              currentUserId={currentUserId}
+              isOwner={isOwner}
+              onRemoveMember={(memberId) => {
+                const member = group.members.find((person) => person.id === memberId)
+                if (!member) return
+                setMemberRemovalCandidate(member)
+              }}
+              onLeaveGroup={handleLeaveGroup}
+            />
+            <GroupJoinRequestsSection
+              requests={group.pendingRequests}
+              onDecision={handleJoinRequestDecision}
+              isOwner={isOwner}
+            />
+          </Stack>
+        </SimpleGrid>
+      </Stack>
+
+      <Modal opened={showSettingsModal} onClose={settingsModalHandlers.close} title="Group settings">
+        <Stack gap="sm">
+          <Text size="sm" c="dimmed">
+            Settings editing is not wired to the backend yet. You can imagine controls for invite links, ownership
+            transfer, and notification schedules here.
+          </Text>
+          <Button onClick={settingsModalHandlers.close}>Close</Button>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={memberRemovalCandidate !== null}
+        onClose={() => setMemberRemovalCandidate(null)}
+        title="Remove member"
+      >
+        <Stack gap="md">
+          <Alert color="yellow" icon={<IconInfoCircle size={18} />} variant="light">
+            Removing a member is immediate in this demo. In production this will call the backend.
+          </Alert>
+          <Text>
+            Do you want to remove {memberRemovalCandidate?.name} from the group?
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="outline" onClick={() => setMemberRemovalCandidate(null)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={() => memberRemovalCandidate && handleRemoveMember(memberRemovalCandidate.id)}>
+              Remove
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Container>
+  )
+}
+
+export default GroupDetailsView

--- a/src/views/GroupsListView.tsx
+++ b/src/views/GroupsListView.tsx
@@ -1,0 +1,92 @@
+import { Alert, Badge, Box, Container, Group, SegmentedControl, SimpleGrid, Stack, Text, Title } from "@mantine/core"
+import { IconInfoCircle } from "@tabler/icons-react"
+import { useMemo, useState } from "react"
+import { useLocation } from "wouter"
+import { UseAuth } from "../context/AuthProvider"
+import { GroupSummaryCard } from "../components/groups/GroupSummaryCard"
+import { mockGroups } from "../data/mockGroups"
+
+const filters = [
+  { label: "All groups", value: "all" },
+  { label: "I'm owner", value: "owner" },
+  { label: "I'm a member", value: "member" },
+]
+
+const GroupsListView = () => {
+  const [, navigate] = useLocation()
+  const { user } = UseAuth()
+  const [filter, setFilter] = useState<string>(filters[0].value)
+
+  const filteredGroups = useMemo(() => {
+    if (!user) return mockGroups
+
+    if (filter === "owner") {
+      return mockGroups.filter((group) => group.ownerId === user.id)
+    }
+
+    if (filter === "member") {
+      return mockGroups.filter((group) =>
+        group.members.some((member) => member.id === user.id && member.role !== "owner")
+      )
+    }
+
+    return mockGroups
+  }, [filter, user])
+
+  return (
+    <Container size="xl" py="xl">
+      <Stack gap="lg">
+        <Group justify="space-between" align="flex-end">
+          <div>
+            <Title order={1}>My groups</Title>
+            <Text size="sm" c="dimmed">
+              Discover and manage your cinema crews
+            </Text>
+          </div>
+          <Badge size="lg" variant="light" color="blue">
+            {mockGroups.length} active groups
+          </Badge>
+        </Group>
+
+        <Box>
+          <SegmentedControl
+            value={filter}
+            onChange={setFilter}
+            data={filters}
+            size="md"
+          />
+          {!user && (
+            <Alert
+              mt="md"
+              variant="light"
+              color="blue"
+              icon={<IconInfoCircle size={18} />}
+              title="Not logged in"
+            >
+              Sign in to see your personal groups.
+            </Alert>
+          )}
+        </Box>
+
+        {filteredGroups.length === 0 ? (
+          <Alert variant="light" color="gray" title="No groups found">
+            You don&apos;t have any groups that match this filter yet. Create one from the mobile app or ask an
+            existing owner to invite you.
+          </Alert>
+        ) : (
+          <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+            {filteredGroups.map((group) => (
+              <GroupSummaryCard
+                key={group.id}
+                group={group}
+                onViewGroup={(id) => navigate(`/groups/${id}`)}
+              />
+            ))}
+          </SimpleGrid>
+        )}
+      </Stack>
+    </Container>
+  )
+}
+
+export default GroupsListView


### PR DESCRIPTION
This pull request introduces a new "Groups" feature to the application, allowing users to view, manage, and interact with movie-going groups. The changes include new routes and navigation for group-related pages, a mock data source for groups, and several new UI components to display group summaries, details, members, showtimes, and join requests. Additionally, new TypeScript types for groups are added to ensure type safety across the new features.

**Groups Feature Implementation:**

* Added new routes for the groups list and group details views in `App.tsx`, and imported the corresponding view components. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R9-R10) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R21-R22)
* Created mock group data in `mockGroups.ts` to provide sample group information, including members, showtimes, and join requests.
* Defined comprehensive TypeScript types for groups, members, showtimes, and join requests in `group.ts`.

**UI Components for Groups:**

* Implemented `GroupSummaryCard` for displaying group summaries, including next showtime and member avatars.
* Added `GroupHeader`, `GroupMembersSection`, `GroupShowtimesSection`, and `GroupJoinRequestsSection` components to render group details, manage members, showtimes, and pending join requests, with owner/admin controls where appropriate. [[1]](diffhunk://#diff-b32c4f077c77ad974457c2a0ea908a623c5b5b4345aa013b4618f98299527a4fR1-R51) [[2]](diffhunk://#diff-e6f08c6ae295e9c6ef2d90d1cc0fc81a21aed37e9b22fbbc2299d70e73ae9ad1R1-R105) [[3]](diffhunk://#diff-723ec8fafb62941d200b56c7385782318d3de99e1238e73048aba7684743e4b5R1-R75) [[4]](diffhunk://#diff-5f60a8f36a4a495305019be56ad65583ac1670b248888b146824f28338aad327R1-R60)

**Navigation Updates:**

* Updated the main layout to include "Groups" in the navigation bar and mobile drawer, ensuring easy access to the new feature. [[1]](diffhunk://#diff-1154f5fda8d578105425211ea49c30fb0eace4f27892123360e9aa5d1c1899cdR92-R105) [[2]](diffhunk://#diff-1154f5fda8d578105425211ea49c30fb0eace4f27892123360e9aa5d1c1899cdR115-R117)